### PR TITLE
alternate implementation of markers

### DIFF
--- a/common/scala/src/whisk/common/ConsulKV.scala
+++ b/common/scala/src/whisk/common/ConsulKV.scala
@@ -27,6 +27,7 @@ import spray.json.JsArray
 import org.apache.jute.compiler.JString
 import spray.json.JsString
 import spray.json.JsObject
+import scala.language.postfixOps
 
 /**
  * See https://www.consul.io/intro/getting-started/kv.html

--- a/common/scala/src/whisk/common/ConsulServiceCheck.scala
+++ b/common/scala/src/whisk/common/ConsulServiceCheck.scala
@@ -25,6 +25,7 @@ import spray.json.JsNull
 import scala.util.Try
 import spray.json.JsArray
 import spray.json.JsObject
+import scala.language.postfixOps
 
 /**
  * Interface with consul receives the host where a consul agent is running

--- a/common/scala/src/whisk/common/Logging.scala
+++ b/common/scala/src/whisk/common/Logging.scala
@@ -23,58 +23,13 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.atomic.AtomicInteger
 
-import scala.util.Try
-
-import spray.json.JsNumber
-import spray.json.JsValue
-import spray.json.RootJsonFormat
-
 object Verbosity extends Enumeration {
     type Level = Value
     val Quiet, Loud, Debug = Value
 }
 
 /**
- * A transaction id.
- */
-case class TransactionId private (id: Long) extends AnyVal {
-    override def toString = if (id > 0) s"#tid_$id" else (if (id < 0) s"#sid_${-id}" else "??")
-}
-
-object TransactionId {
-    val unknown = TransactionId(0)
-    val testing = TransactionId(-1)                  // unit testing
-    val invoker = TransactionId(-100)                // Invoker startup/shutdown or GC activity
-    val invokerWarmup = TransactionId(-101)          // Invoker warmup thread
-
-    def apply(tid: BigDecimal): Try[TransactionId] = {
-        Try { TransactionId(tid.toLong) }
-    }
-
-    implicit val serdes = new RootJsonFormat[TransactionId] {
-        def write(t: TransactionId) = JsNumber(t.id)
-
-        def read(value: JsValue) = Try {
-            val JsNumber(tid) = value
-            TransactionId(tid.longValue)
-        } getOrElse unknown
-    }
-}
-
-/**
- * A thread-safe transaction counter.
- */
-trait TransactionCounter {
-    def transid(): TransactionId = {
-        TransactionId(cnt.incrementAndGet())
-    }
-
-    private val cnt = new AtomicInteger(1)
-}
-
-/**
  * A logging facility in which output is one line and fields are bracketed.
- *
  */
 trait Logging {
     var outputStream: PrintStream = Console.out
@@ -87,37 +42,52 @@ trait Logging {
     def setComponentName(comp: String) =
         this.componentName = comp
 
-    def debug(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
-        if (level == Verbosity.Debug)
-            emit("DEBUG", id, from, message)
+    def debug(from: AnyRef, message: String, marker: String = null)(implicit id: TransactionId = TransactionId.unknown) = {
+        val mark = id.mark(marker)
+        if (level == Verbosity.Debug || mark.isDefined)
+            emit("DEBUG", id, from, message, mark)
+    }
 
-    def info(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
-        if (level != Verbosity.Quiet)
-            emit("INFO", id, from, message)
+    def info(from: AnyRef, message: String, marker: String = null)(implicit id: TransactionId = TransactionId.unknown) = {
+        val mark = id.mark(marker)
+        if (level != Verbosity.Quiet || mark.isDefined)
+            emit("INFO", id, from, message, mark)
+    }
 
-    def warn(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
-        if (level != Verbosity.Quiet)
-            emit("WARN", id, from, message)
+    def warn(from: AnyRef, message: String, marker: String = null)(implicit id: TransactionId = TransactionId.unknown) = {
+        val mark = id.mark(marker)
+        if (level != Verbosity.Quiet || mark.isDefined)
+            emit("WARN", id, from, message, mark)
+    }
 
-    def error(from: AnyRef, message: String)(implicit id: TransactionId = TransactionId.unknown) =
-        emit("ERROR", id, from, message)
+    def error(from: AnyRef, message: String, marker: String = null)(implicit id: TransactionId = TransactionId.unknown) = {
+        emit("ERROR", id, from, message, id.mark(marker))
+    }
 
-    def emit(category: AnyRef, id: TransactionId, from: AnyRef, message: String) = {
-        val now = Instant.now(Clock.systemUTC())
+    def emit(category: AnyRef, id: TransactionId, from: AnyRef, message: String, mark: Option[LogMarker] = None) = {
+        val now = mark map { _.now } getOrElse Instant.now(Clock.systemUTC)
         val time = Logging.timeFormat.format(now)
-        val name = if (from.isInstanceOf[String]) {
-            from
-        } else Logging.getCleanSimpleClassName(from.getClass)
-        if (componentName != "")
-            outputStream.println(s"[$time] [$category] [$id] [$componentName] [$name] $message")
-        else
-            outputStream.println(s"[$time] [$category] [$id] [$name] $message")
+        val name = if (from.isInstanceOf[String]) from else Logging.getCleanSimpleClassName(from.getClass)
+        val msg = mark map { m => s"[marker:${m.token}:${m.delta}] $message" } getOrElse message
+
+        if (componentName != "") {
+            outputStream.println(s"[$time] [$category] [$id] [$componentName] [$name] $msg")
+        } else {
+            outputStream.println(s"[$time] [$category] [$id] [$name] $msg")
+        }
     }
 
     private var level = Verbosity.Quiet
     private var componentName = "";
     private var sequence = new AtomicInteger()
 }
+
+/**
+ * A triple representing the timestamp relative to which the elapsed time was computed,
+ * typically for a TransactionId, the elapsed time in milliseconds and a string containing
+ * the given marker token.
+ */
+protected case class LogMarker(now: Instant, delta: Long, token: String)
 
 private object Logging {
     /**
@@ -132,4 +102,28 @@ private object Logging {
     private val timeFormat = DateTimeFormatter.
         ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").
         withZone(ZoneId.of("UTC"))
+}
+
+object LoggingMarkers {
+    val CONTROLLER_CREATE_ACTIVATION = "controller_create_activation"
+    val LOADBALANCER_POST_KAFKA = "loadbalancer_post_kafka"
+    val CONTROLLER_ACTIVATION_END = "controller_activation_end"
+    val CONTROLLER_BLOCKING_ACTIVATION_END = "controller_blocking_activation_end"
+    val CONTROLLER_BLOCK_FOR_RESULT = "controller_block_for_result"
+    val CONTROLLER_ACTIVATION_REJECTED = "controller_activation_rejected"
+    val CONTROLLER_ACTIVATION_FAILED = "controller_activation_failed"
+    val INVOKER_FETCH_ACTION_START = "invoker_fetch_action_start"
+    val INVOKER_FETCH_ACTION_DONE = "invoker_fetch_action_done"
+    val INVOKER_FETCH_ACTION_FAILED = "invoker_fetch_action_failed"
+    val INVOKER_FETCH_AUTH_START = "invoker_fetch_auth_start"
+    val INVOKER_FETCH_AUTH_DONE = "invoker_fetch_auth_done"
+    val INVOKER_FETCH_AUTH_FAILED = "invoker_fetch_auth_failed"
+    val INVOKER_GET_CONTAINER_START = "invoker_get_container_start"
+    val INVOKER_GET_CONTAINER_DONE = "invoker_get_container_done"
+    val INVOKER_CONTAINER_INIT = "invoker_container_init"
+    val INVOKER_SEND_ARGS = "invoker_send_args"
+    val INVOKER_ACTIVATION_END = "invoker_activation_end"
+    val INVOKER_RECORD_ACTIVATION_START = "invoker_record_activation_start"
+    val INVOKER_RECORD_ACTIVATION_DONE = "invoker_record_activation_done"
+    val INVOKER_FAILED_ACTIVATION = "invoker_failed_activation"
 }

--- a/common/scala/src/whisk/common/TransactionId.scala
+++ b/common/scala/src/whisk/common/TransactionId.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015-2016 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package whisk.common
+
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+import scala.math.BigDecimal.int2bigDecimal
+import scala.util.Try
+
+import spray.json.JsArray
+import spray.json.JsNumber
+import spray.json.JsValue
+import spray.json.RootJsonFormat
+
+/**
+ * A transaction id for tracking operations in the system that are specific to a request.
+ * An instance of TransactionId is implicitly received by all logging methods. This is a
+ * value type so that the type system ensures it is never null. The actual metadata is stored
+ * indirectly in the referenced meta object.
+ */
+case class TransactionId private (meta: TransactionMetadata) extends AnyVal {
+    override def toString = if (meta.id > 0) s"#tid_${meta.id}" else (if (meta.id < 0) s"#sid_${-meta.id}" else "??")
+
+    /**
+     * Computes elapsed milliseconds since start of transaction if given token is defined.
+     *
+     * @param token the marker name
+     * @return Some LogMarker iff token is defined and None otherwise
+     */
+    def mark(token: String): Option[LogMarker] = {
+        val now = Instant.now(Clock.systemUTC())
+        Option(token) filter { _.trim.nonEmpty } map { _ =>
+            val delta = now.toEpochMilli - meta.start.toEpochMilli
+            LogMarker(now, delta, token.trim)
+        }
+    }
+}
+
+/**
+ * The transaction metadata encapsulates important properties about a transaction.
+ *
+ * @param id the transaction identifier; it is positive for client requests,
+ *           negative for system operation and zero when originator is not known
+ * @param start the timestamp when the request processing commenced
+ */
+protected case class TransactionMetadata(val id: Long, val start: Instant)
+
+object TransactionId {
+    val unknown = TransactionId(0)
+    val testing = TransactionId(-1) // a common id for for unit testing
+    val invoker = TransactionId(-100) // Invoker startup/shutdown or GC activity
+    val invokerWarmup = TransactionId(-101) // Invoker warmup thread
+
+    def apply(tid: BigDecimal): TransactionId = {
+        Try {
+            val now = Instant.now(Clock.systemUTC())
+            TransactionId(TransactionMetadata(tid.toLong, now))
+        } getOrElse unknown
+    }
+
+    implicit val serdes = new RootJsonFormat[TransactionId] {
+        def write(t: TransactionId) = JsArray(JsNumber(t.meta.id), JsNumber(t.meta.start.toEpochMilli))
+
+        def read(value: JsValue) = Try {
+            value match {
+                case JsArray(Vector(JsNumber(id), JsNumber(start))) =>
+                    TransactionId(TransactionMetadata(id.longValue, Instant.ofEpochMilli(start.longValue)))
+            }
+        } getOrElse unknown
+    }
+}
+
+/**
+ * A thread-safe transaction counter.
+ */
+trait TransactionCounter {
+    def transid(): TransactionId = {
+        TransactionId(cnt.incrementAndGet())
+    }
+
+    private val cnt = new AtomicInteger(1)
+}

--- a/common/scala/src/whisk/connector/kafka/KafkaConsumerConnector.scala
+++ b/common/scala/src/whisk/connector/kafka/KafkaConsumerConnector.scala
@@ -17,6 +17,7 @@
 package whisk.connector.kafka
 
 import java.util.Properties
+import scala.language.postfixOps
 
 import scala.collection.JavaConversions.iterableAsScalaIterable
 import scala.collection.JavaConversions.seqAsJavaList

--- a/common/scala/src/whisk/core/connector/LoadbalancerRequest.scala
+++ b/common/scala/src/whisk/core/connector/LoadbalancerRequest.scala
@@ -17,6 +17,7 @@
 package whisk.core.connector
 
 import scala.concurrent.ExecutionContext
+import scala.language.postfixOps
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 

--- a/common/scala/src/whisk/core/connector/Message.scala
+++ b/common/scala/src/whisk/core/connector/Message.scala
@@ -83,14 +83,5 @@ object ActivationMessage extends DefaultJsonProtocol {
         serdes.read(msg.parseJson)
     }
 
-    private implicit object TransidJsonFormat extends RootJsonFormat[TransactionId] {
-        def write(tid: TransactionId) = tid.id.toJson
-
-        def read(value: JsValue) = Try {
-            val JsNumber(tid) = value
-            TransactionId(tid).get
-        } getOrElse deserializationError("transaction id malformed")
-    }
-
     implicit val serdes = jsonFormat6(ActivationMessage.apply)
 }

--- a/common/scala/src/whisk/core/database/CouchDbLikeStore.scala
+++ b/common/scala/src/whisk/core/database/CouchDbLikeStore.scala
@@ -28,6 +28,7 @@ import whisk.common.TransactionId
 import whisk.core.entity.DocInfo
 import whisk.utils.ExecutionContextFactory
 import spray.json.JsArray
+import scala.language.postfixOps
 
 /**
  * Basic client to put and delete artifacts in a data store.

--- a/common/scala/src/whisk/core/database/CouchDbRestStore.scala
+++ b/common/scala/src/whisk/core/database/CouchDbRestStore.scala
@@ -160,7 +160,6 @@ class CouchDbRestStore[Unused, DocumentAbstraction <: DocumentSerializer](
             require(doc != null, "doc undefined")
             require(deserialize != null, "deserializer undefined")
             info(this, s"[GET] '$dbName' finding document: '$doc'")
-
             val request: CouchDbRestClient=>Future[Either[StatusCode,JsObject]] = if(doc.rev.rev != null) {
                 client => client.getDoc(doc.id.id, doc.rev.rev)
             } else {
@@ -172,7 +171,6 @@ class CouchDbRestStore[Unused, DocumentAbstraction <: DocumentSerializer](
             ) yield eitherResponse match {
                     case Right(response) =>
                         info(this, s"[GET] '$dbName' completed: found document '$doc', response: '$response'")
-
                         val asFormat = jsonFormat.read(response)
                         // For backwards compatibility, we should fail with IllegalArgumentException
                         // if the retrieved type doesn't match the expected type. The following does

--- a/common/scala/src/whisk/core/database/DocumentFactory.scala
+++ b/common/scala/src/whisk/core/database/DocumentFactory.scala
@@ -26,6 +26,7 @@ import whisk.common.Logging
 import scala.concurrent.Promise
 import whisk.core.entity.DocRevision
 import whisk.core.entity.DocRevision
+import scala.language.implicitConversions
 
 /**
  * A common trait for all records that are stored in the datastore requiring an _id field,

--- a/common/scala/src/whisk/core/entity/ActivationId.scala
+++ b/common/scala/src/whisk/core/entity/ActivationId.scala
@@ -27,6 +27,7 @@ import spray.json.JsValue
 import spray.json.RootJsonFormat
 import spray.json.deserializationError
 import spray.json.pimpAny
+import scala.language.postfixOps
 
 /**
  * An activation id, is a unique id assigned to activations (invoke action or fire trigger).

--- a/common/scala/src/whisk/core/entity/Parameter.scala
+++ b/common/scala/src/whisk/core/entity/Parameter.scala
@@ -33,6 +33,8 @@ import spray.json.DefaultJsonProtocol.mapFormat
 import spray.json.RootJsonFormat
 import spray.json.deserializationError
 import spray.json.pimpAny
+import scala.language.postfixOps
+import scala.language.reflectiveCalls
 
 /**
  * Parameters is a key-value map from parameter names to parameter values. The value of a

--- a/common/scala/src/whisk/core/entity/TimeLimit.scala
+++ b/common/scala/src/whisk/core/entity/TimeLimit.scala
@@ -25,6 +25,7 @@ import spray.json.JsValue
 import spray.json.JsNumber
 import spray.json.RootJsonFormat
 import scala.util.Try
+import scala.language.postfixOps
 
 /**
  * TimeLimit encapsulates a duration for an action. The duration must be within a

--- a/common/scala/src/whisk/core/entity/WhiskPackage.scala
+++ b/common/scala/src/whisk/core/entity/WhiskPackage.scala
@@ -35,6 +35,7 @@ import spray.json.RootJsonFormat
 import spray.json.JsString
 import spray.json.deserializationError
 import spray.json.JsArray
+import scala.language.postfixOps
 
 /**
  * WhiskPackagePut is a restricted WhiskPackage view that eschews properties

--- a/common/scala/src/whisk/core/entity/WhiskStore.scala
+++ b/common/scala/src/whisk/core/entity/WhiskStore.scala
@@ -44,6 +44,7 @@ import whisk.core.entity.schema.ActivationRecord
 import whisk.core.entity.schema.AuthRecord
 import whisk.core.entity.schema.EntityRecord
 import java.time.Instant
+import scala.language.postfixOps
 
 package object types {
     type AuthStore = ArtifactStore[AuthRecord, WhiskAuth]

--- a/common/scala/src/whisk/core/entity/schema/migration/MigrationAssistant.scala
+++ b/common/scala/src/whisk/core/entity/schema/migration/MigrationAssistant.scala
@@ -28,6 +28,7 @@ import whisk.core.database.CloudantProvider
 import whisk.core.entity.DocRevision
 import whisk.core.entity.WhiskAuth
 import whisk.core.entity.schema.AuthRecord
+import scala.language.postfixOps
 
 protected[entity] object CloudantReader {
 

--- a/common/scala/src/whisk/utils/ExecutionContextFactory.scala
+++ b/common/scala/src/whisk/utils/ExecutionContextFactory.scala
@@ -26,6 +26,7 @@ import scala.concurrent.duration.FiniteDuration
 import akka.actor.ActorSystem
 import akka.pattern.after
 import java.util.concurrent.Executors
+import scala.language.postfixOps
 
 object ExecutionContextFactory {
 

--- a/common/scala/src/whisk/utils/JsonUtils.scala
+++ b/common/scala/src/whisk/utils/JsonUtils.scala
@@ -31,6 +31,7 @@ import spray.json.JsValue
 import spray.json.JsArray
 import com.google.gson.JsonPrimitive
 import com.google.gson.JsonNull
+import scala.language.postfixOps
 
 /**
  * Utility functions for manipulating Json objects

--- a/common/scala/src/whisk/utils/Retry.scala
+++ b/common/scala/src/whisk/utils/Retry.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
+import scala.language.postfixOps
 
 object retry {
     /**

--- a/core/controller/src/whisk/core/controller/Actions.scala
+++ b/core/controller/src/whisk/core/controller/Actions.scala
@@ -54,6 +54,7 @@ import spray.json.pimpString
 import spray.json.pimpAny
 import whisk.common.ConsulKV
 import whisk.common.ConsulKV.LoadBalancerKeys
+import whisk.common.LoggingMarkers._
 import whisk.common.TransactionId
 import whisk.core.WhiskConfig
 import whisk.core.entity.ActionLimits
@@ -388,21 +389,23 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
         // merge package parameters with action (action parameters supersede), then merge in payload
         val args = { env map { _ ++ action.parameters } getOrElse action.parameters } merge payload
         val message = Message(transid, s"/actions/invoke/${action.namespace}/${action.name}/${action.rev}", user, ActivationId(), args)
-        info(this, s"[POST] action activation id: ${message.activationId}")
+
+        info(this, s"[POST] action activation id: ${message.activationId}", CONTROLLER_CREATE_ACTIVATION)
         performLoadBalancerRequest(INVOKER, message, transid) map {
             (action.limits.timeout(), _)
         } flatMap {
             case (duration, response) =>
                 response.id match {
                     case Some(activationId) =>
+                        info(this, "", CONTROLLER_ACTIVATION_END)
                         Future successful (duration, activationId)
                     case None =>
                         if (response.error.getOrElse("??").equals("too many concurrent activations")) {
-                            // got here because of DoS throttle
-                            warn(this, s"[POST] action activation rejected: ${response.error.getOrElse("??")}")
+                            // DoS throttle
+                            warn(this, s"[POST] action activation rejected: ${response.error.getOrElse("??")}", CONTROLLER_ACTIVATION_REJECTED)
                             Future failed new TooManyActivationException("too many concurrent activations")
                         } else {
-                            error(this, s"[POST] action activation failed: ${response.error.getOrElse("??")}")
+                            error(this, s"[POST] action activation failed: ${response.error.getOrElse("??")}", CONTROLLER_ACTIVATION_FAILED)
                             Future failed new IllegalStateException(s"activation failed with error: ${response.error.getOrElse("??")}")
                         }
                 }
@@ -412,10 +415,11 @@ trait WhiskActionsApi extends WhiskCollectionAPI {
                     val docid = DocId(WhiskEntity.qualifiedName(user.namespace, activationId))
                     val timeout = duration + blockingInvokeGrace
                     val promise = Promise[(ActivationId, Option[WhiskActivation])]
-                    info(this, s"[POST] action activation will block on result up to $timeout ($duration + $blockingInvokeGrace grace)")
+                    info(this, s"[POST] action activation will block on result up to $timeout ($duration + $blockingInvokeGrace grace)", CONTROLLER_BLOCK_FOR_RESULT)
                     pollForResult(docid.asDocInfo, activationId, promise)
                     val response = promise.future withTimeout (timeout, new BlockingInvokeTimeout(activationId))
                     response onFailure { case t => promise.tryFailure(t) } // short circuits polling on result
+                    info(this, "", CONTROLLER_BLOCKING_ACTIVATION_END)
                     response // will either complete with activation or fail with timeout
                 } else Future { (activationId, None) }
         }

--- a/core/controller/src/whisk/core/controller/Actions.scala
+++ b/core/controller/src/whisk/core/controller/Actions.scala
@@ -90,6 +90,7 @@ import whisk.core.entity.WhiskEntityQueries
 import whisk.http.ErrorResponse
 import whisk.http.ErrorResponse.{ terminate }
 import spray.routing.RequestContext
+import scala.language.postfixOps
 
 object WhiskActionsApi {
     def requiredProperties = WhiskServices.requiredProperties ++

--- a/core/controller/src/whisk/core/controller/Activations.scala
+++ b/core/controller/src/whisk/core/controller/Activations.scala
@@ -51,6 +51,7 @@ import whisk.core.entitlement.Privilege
 import whisk.core.entitlement.Privilege.READ
 import whisk.core.entitlement.Resource
 import whisk.core.entity.WhiskAuth
+import scala.language.postfixOps
 
 object WhiskActivationsApi {
     def requiredProperties = WhiskActivationStore.requiredProperties

--- a/core/controller/src/whisk/core/controller/AuthorizedRouteDispatcher.scala
+++ b/core/controller/src/whisk/core/controller/AuthorizedRouteDispatcher.scala
@@ -45,6 +45,7 @@ import scala.util.Failure
 import scala.util.Success
 import whisk.http.ErrorResponse.{ terminate }
 import whisk.http.ErrorResponse
+import scala.language.postfixOps
 
 /** A trait for routes that require entitlement checks. */
 trait BasicAuthorizedRouteProvider extends Directives with Logging {

--- a/core/controller/src/whisk/core/controller/Backend.scala
+++ b/core/controller/src/whisk/core/controller/Backend.scala
@@ -51,6 +51,7 @@ import whisk.core.entitlement.EntitlementService
 import whisk.core.entitlement.LocalEntitlementService
 import whisk.core.entitlement.RemoteEntitlementService
 import whisk.core.loadBalancer.LoadBalancerService
+import scala.language.postfixOps
 
 object WhiskServices extends LoadbalancerRequest {
 

--- a/core/controller/src/whisk/core/controller/Entities.scala
+++ b/core/controller/src/whisk/core/controller/Entities.scala
@@ -39,6 +39,7 @@ import whisk.core.entity.Namespace
 import whisk.core.entity.Parameters
 import whisk.core.entity.Subject
 import whisk.http.ErrorResponse.terminate
+import scala.language.postfixOps
 
 /** A trait implementing the basic operations on WhiskEntities in support of the various APIs. */
 trait WhiskCollectionAPI

--- a/core/controller/src/whisk/core/controller/Rules.scala
+++ b/core/controller/src/whisk/core/controller/Rules.scala
@@ -68,6 +68,7 @@ import whisk.core.entity.ActivationId
 import whisk.core.connector.{ ActivationMessage => Message }
 import whisk.core.connector.ActivationMessage.{ publish, ACTIVATOR }
 import whisk.http.ErrorResponse.{ terminate }
+import scala.language.postfixOps
 
 object WhiskRulesApi {
     def requiredProperties = WhiskServices.requiredProperties ++

--- a/core/controller/src/whisk/core/entitlement/Entitlement.scala
+++ b/core/controller/src/whisk/core/entitlement/Entitlement.scala
@@ -36,6 +36,7 @@ import whisk.core.entity.Namespace
 import whisk.core.entity.Parameters
 import whisk.core.entity.Subject
 import whisk.http.ErrorResponse
+import scala.language.postfixOps
 
 package object types {
     type Entitlements = TrieMap[(Subject, String), Set[Privilege]]

--- a/core/dispatcher/src/whisk/core/container/ContainerUtils.scala
+++ b/core/dispatcher/src/whisk/core/container/ContainerUtils.scala
@@ -22,6 +22,7 @@ import whisk.common.TransactionId
 import whisk.core.entity.ActionLimits
 import java.io.File
 import scala.util.Try
+import scala.language.postfixOps
 
 /**
  * Information from docker ps.

--- a/core/dispatcher/src/whisk/core/container/WhiskContainer.scala
+++ b/core/dispatcher/src/whisk/core/container/WhiskContainer.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import spray.json.JsObject
 import spray.json.JsString
 import whisk.common.HttpUtils
+import whisk.common.LoggingMarkers._
 import whisk.common.TransactionId
 import whisk.core.entity.ActionLimits
 
@@ -42,7 +43,7 @@ class WhiskContainer(
     args: Array[String] = Array())
     extends Container(originalId, pool, key, Some(containerName), image, network, pull, limits, env, args) {
 
-    var boundParams = JsObject()  // Mutable to support pre-alloc containers
+    var boundParams = JsObject() // Mutable to support pre-alloc containers
     var lastLogSize = 0L
     val initTimeoutMilli = 60000
 
@@ -67,7 +68,6 @@ class WhiskContainer(
         JsObject(boundParams.fields ++ payload.fields)
     }
 
-
     /**
      * Send initialization payload to container.
      */
@@ -75,8 +75,8 @@ class WhiskContainer(
         val start = ContainerCounter.now()
         // this shouldn't be needed but leave it for now
         if (isBlackbox) Thread.sleep(3000)
-        info(this, s"sending initialization to ${this.details}")
-        val result = sendPayload("/init", JsObject("value" -> args), initTimeoutMilli)   // This will retry.
+        info(this, s"sending initialization to ${this.details}", INVOKER_CONTAINER_INIT)
+        val result = sendPayload("/init", JsObject("value" -> args), initTimeoutMilli) // This will retry.
         val end = ContainerCounter.now()
         info(this, s"initialization result: ${result}")
         (start, end, result)
@@ -88,12 +88,11 @@ class WhiskContainer(
      * @param state the value of the status to compare the actual state against
      * @return triple of start time, end time, response for user action.
      */
-    def run(args: JsObject, meta: JsObject, authKey : String, timeout: Int, actionName: String, activationId: String)
-           (implicit transid: TransactionId): RunResult = {
+    def run(args: JsObject, meta: JsObject, authKey: String, timeout: Int, actionName: String, activationId: String)(implicit transid: TransactionId): RunResult = {
         val start = ContainerCounter.now()
-        info("Invoker", s"sending arguments to $actionName $details")
+        info("Invoker", s"sending arguments to $actionName $details", INVOKER_SEND_ARGS)
         val response = sendPayload("/run", JsObject(meta.fields + ("value" -> args) + ("authKey" -> JsString(authKey))), timeout)
-        info("Invoker", s"finished running activation id: $activationId")
+        info("Invoker", s"finished running activation id: $activationId", INVOKER_ACTIVATION_END)
         (start, ContainerCounter.now(), response)
     }
 

--- a/core/dispatcher/src/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/whisk/core/invoker/Invoker.scala
@@ -73,6 +73,7 @@ import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.WhiskEntity
 import whisk.core.entity.WhiskEntityStore
 import whisk.http.BasicHttpService
+import scala.language.postfixOps
 
 /**
  * A kafka message handler that invokes actions as directed by message on topic "/actions/invoke".

--- a/core/dispatcher/src/whisk/core/invoker/Invoker.scala
+++ b/core/dispatcher/src/whisk/core/invoker/Invoker.scala
@@ -41,6 +41,7 @@ import whisk.common.ConsulKV
 import whisk.common.ConsulKV.InvokerKeys
 import whisk.common.ConsulKVReporter
 import whisk.common.Counter
+import whisk.common.LoggingMarkers._
 import whisk.common.SimpleExec
 import whisk.common.TransactionId
 import whisk.common.Verbosity
@@ -150,29 +151,36 @@ class Invoker(
         // caching is enabled since actions have revision id and an updated
         // action will not hit in the cache due to change in the revision id;
         // if the doc revision is missing, then bypass cache
+        info(this, "", INVOKER_FETCH_ACTION_START)
         val actionFuture = WhiskAction.get(entityStore, action, action.rev != DocRevision())
         actionFuture onFailure {
-            case t => error(this, s"failed to fetch action ${action.id}: ${t.getMessage}")
+            case t => error(this, s"failed to fetch action ${action.id}: ${t.getMessage}", INVOKER_FETCH_ACTION_FAILED)
         }
 
+        info(this, "", INVOKER_FETCH_AUTH_START)
         // keys are immutable, cache them
         val authFuture = WhiskAuth.get(authStore, subject, true)
         authFuture onFailure {
-            case t => error(this, s"failed to fetch auth key for $subject: ${t.getMessage}")
+            case t => error(this, s"failed to fetch auth key for $subject: ${t.getMessage}", INVOKER_FETCH_AUTH_FAILED)
         }
 
         // when records are fetched, invoke action
         val activationDocFuture =
             actionFuture flatMap { theAction =>
+                // assume this future is done here
+                info(this, "", INVOKER_FETCH_ACTION_DONE)
                 authFuture flatMap { theAuth =>
+                    // assume this future is done here
+                    info(this, "", INVOKER_FETCH_AUTH_DONE)
                     invokeAction(theAction, theAuth, payload, tran)
                 }
             }
         activationDocFuture onComplete {
             case Success(activationDoc) =>
-                info(this, s"recorded activation '$activationDoc'")
+                info(this, s"recorded activation '$activationDoc'", INVOKER_ACTIVATION_END)
                 activationDoc
             case Failure(t) =>
+                info(this, s"action ${action.id}", INVOKER_FAILED_ACTIVATION)
                 completeTransactionWithError(action, tran, s"failed to invoke action ${action.id}: ${t.getMessage}")
         }
 
@@ -212,7 +220,9 @@ class Invoker(
                     activationCounter.next() // this is the global invoker counter
                     incrementUserActivationCounter(tran.msg.subject)
                     // Since there is no active action taken for completion from the invoker, writing activation record is it.
+                    info(this, "recording the activation result to the data store", INVOKER_RECORD_ACTIVATION_START)
                     val result = WhiskActivation.put(activationStore, activation)
+                    info(this, "finished recording the activation result", INVOKER_RECORD_ACTIVATION_DONE)
                     tran.result = Some(result)
                     result
                 }
@@ -274,7 +284,7 @@ class Invoker(
 
     /**
      * Waits for log cursor to advance. This will retry up to 'abort' times
-     * if the curor has not yet advanced. This will penalize containers that
+     * if the cursor has not yet advanced. This will penalize containers that
      * do not log. It is OK for nodejs containers because the runtime emits
      * the END_OF_ACTIVATION_MARKER automatically and that advances the cursor.
      *

--- a/core/dispatcher/src/whisk/core/invoker/InvokerServer.scala
+++ b/core/dispatcher/src/whisk/core/invoker/InvokerServer.scala
@@ -39,6 +39,7 @@ import scala.util.Try
 import scala.util.Failure
 import scala.util.Success
 import scala.concurrent.ExecutionContext
+import scala.language.postfixOps
 
 /**
  * Implements web server to handle certain REST API calls for testing.

--- a/core/loadBalancer/src/whisk/core/loadBalancer/ActivationThrottle.scala
+++ b/core/loadBalancer/src/whisk/core/loadBalancer/ActivationThrottle.scala
@@ -28,6 +28,7 @@ import whisk.common.ConsulKV
 import whisk.common.ConsulKV.LoadBalancerKeys
 import whisk.common.Counter
 import whisk.common.Logging
+import scala.language.postfixOps
 
 
 class ActivationThrottle(consulServer: String,

--- a/core/loadBalancer/src/whisk/core/loadBalancer/InvokerHealth.scala
+++ b/core/loadBalancer/src/whisk/core/loadBalancer/InvokerHealth.scala
@@ -36,6 +36,7 @@ import whisk.common.Verbosity
 import whisk.core.WhiskConfig
 import whisk.core.WhiskConfig.consulServer
 import whisk.core.connector.{ ActivationMessage => Message }
+import scala.language.postfixOps
 
 object InvokerHealth {
     val requiredProperties = consulServer

--- a/core/loadBalancer/src/whisk/core/loadBalancer/LoadBalancerToKafka.scala
+++ b/core/loadBalancer/src/whisk/core/loadBalancer/LoadBalancerToKafka.scala
@@ -23,6 +23,7 @@ import scala.concurrent.Future
 import spray.json.JsObject
 import whisk.common.Counter
 import whisk.common.Logging
+import whisk.common.LoggingMarkers._
 import whisk.common.TransactionId
 import whisk.common.Verbosity
 import whisk.connector.kafka.KafkaProducerConnector
@@ -61,7 +62,7 @@ trait LoadBalancerToKafka extends Logging {
                     info(this, s"(DoS) '$subject' maxed concurrent invocations")
                     Future.successful(throttleError)
                 } else {
-                    info(this, s"posting topic '$topic' with activation id '${msg.activationId}'")
+                    info(this, s"posting topic '$topic' with activation id '${msg.activationId}'", LOADBALANCER_POST_KAFKA)
                     producer.send(topic, msg) map { status =>
                         if (component == Message.INVOKER) {
                             activationCounter.next()

--- a/tests/src/common/Wsk.scala
+++ b/tests/src/common/Wsk.scala
@@ -33,6 +33,7 @@ import TestUtils.SUCCESS_EXIT
 import common.TestUtils.RunResult
 import spray.json.JsValue
 import whisk.utils.retry
+import scala.language.postfixOps
 
 /**
  * Provide Scala bindings for the whisk CLI.

--- a/tests/src/services/KafkaConnectorTests.scala
+++ b/tests/src/services/KafkaConnectorTests.scala
@@ -35,6 +35,7 @@ import whisk.connector.kafka.KafkaProducerConnector
 import whisk.core.WhiskConfig
 import whisk.core.connector.Message
 import whisk.utils.ExecutionContextFactory
+import scala.language.postfixOps
 
 @RunWith(classOf[JUnitRunner])
 class KafkaConnectorTests extends FlatSpec with Matchers with BeforeAndAfter {

--- a/tests/src/whisk/consul/ConsulKVTests.scala
+++ b/tests/src/whisk/consul/ConsulKVTests.scala
@@ -29,6 +29,8 @@ import spray.json.JsString
 import spray.json.JsNull
 import spray.json.JsValue
 import scala.concurrent.duration._
+import scala.language.reflectiveCalls
+import scala.language.postfixOps
 
 @RunWith(classOf[JUnitRunner])
 class ConsulKVTests extends FlatSpec with Matchers {

--- a/tests/src/whisk/core/activator/test/ActivatorTests.scala
+++ b/tests/src/whisk/core/activator/test/ActivatorTests.scala
@@ -47,6 +47,8 @@ import whisk.core.entity.Status
 import whisk.core.entity.Subject
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.entity.WhiskRule
+import scala.language.postfixOps
+import scala.language.reflectiveCalls
 
 @RunWith(classOf[JUnitRunner])
 class ActivatorTests extends FlatSpec

--- a/tests/src/whisk/core/container/test/ContainerPoolTests.scala
+++ b/tests/src/whisk/core/container/test/ContainerPoolTests.scala
@@ -47,6 +47,7 @@ import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.WhiskEntityStore
 import whisk.utils.ExecutionContextFactory
+import scala.language.postfixOps
 
 /**
  * Unit tests for ContainerPool and, by association, Container and WhiskContainer.

--- a/tests/src/whisk/core/controller/test/AuthorizeTests.scala
+++ b/tests/src/whisk/core/controller/test/AuthorizeTests.scala
@@ -49,6 +49,7 @@ import whisk.core.entity.Namespace
 import whisk.core.entitlement.Collection._
 import whisk.core.entitlement.Resource
 import whisk.core.entitlement.Privilege._
+import scala.language.postfixOps
 
 /**
  * Tests authorization handler which guards resources.

--- a/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
+++ b/tests/src/whisk/core/controller/test/PackageActionsApiTests.scala
@@ -63,6 +63,7 @@ import whisk.core.controller.WhiskPackagesApi
 import whisk.core.entity.WhiskPackagePut
 import whisk.core.entity.WhiskEntity
 import whisk.utils.retry
+import scala.language.postfixOps
 
 /**
  * Tests Packages API.

--- a/tests/src/whisk/core/controller/test/RulesApiTests.scala
+++ b/tests/src/whisk/core/controller/test/RulesApiTests.scala
@@ -54,6 +54,7 @@ import whisk.http.ErrorResponse
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.duration.SECONDS
+import scala.language.postfixOps
 
 /**
  * Tests Rules API.

--- a/tests/src/whisk/core/database/test/DbUtils.scala
+++ b/tests/src/whisk/core/database/test/DbUtils.scala
@@ -43,6 +43,7 @@ import whisk.core.entity.DocId
 import java.util.concurrent.TimeoutException
 import whisk.common.TransactionCounter
 import whisk.utils.ExecutionContextFactory
+import scala.language.postfixOps
 
 trait DbUtils extends TransactionCounter {
 

--- a/tests/src/whisk/core/entity/test/SchemaTests.scala
+++ b/tests/src/whisk/core/entity/test/SchemaTests.scala
@@ -46,6 +46,8 @@ import whisk.core.entity.Secret
 import whisk.core.entity.SemVer
 import whisk.core.entity.TimeLimit
 import whisk.core.entity.UUID
+import scala.language.postfixOps
+import scala.language.reflectiveCalls
 
 @RunWith(classOf[JUnitRunner])
 class SchemaTests extends FlatSpec with BeforeAndAfter {

--- a/tests/src/whisk/core/entity/test/ViewTests.scala
+++ b/tests/src/whisk/core/entity/test/ViewTests.scala
@@ -57,6 +57,7 @@ import whisk.core.entity.WhiskRule
 import whisk.core.entity.WhiskTrigger
 import java.util.Date
 import org.scalatest.BeforeAndAfterAll
+import scala.language.postfixOps
 
 @RunWith(classOf[JUnitRunner])
 class ViewTests extends FlatSpec

--- a/tests/src/whisk/core/invoker/test/InvokerTests.scala
+++ b/tests/src/whisk/core/invoker/test/InvokerTests.scala
@@ -52,6 +52,7 @@ import whisk.core.entity.WhiskAuth
 import whisk.core.entity.WhiskAuthStore
 import whisk.core.entity.WhiskEntityStore
 import whisk.core.invoker.Invoker
+import scala.language.postfixOps
 
 @RunWith(classOf[JUnitRunner])
 class InvokerTests extends FlatSpec


### PR DESCRIPTION
in this alternate implementation, the transaction mark is factored into the `TransactionId` class and the logging methods add an optional `marker` token, which when present, compute the deltas. This avoids having to introduce a new `marker` method with an additional log level argument (while I suggested this previously, I think reusing the existing loggers is a better alternative). The nice feature of the `marker` method is that the token is upfront whereas in this case, the marker is at the tail of the method call (using positional arguments; if not using positional arguments, it make the log message a bit more verbose but perhaps this is better, making it clear the marker is present upfront. I opted for positional arguments nonetheless pending review and comments.)
